### PR TITLE
Parse file format version numbers to int

### DIFF
--- a/beatmap.go
+++ b/beatmap.go
@@ -17,7 +17,7 @@ type Beatmap struct {
 	Version           string
 	BeatmapID         int
 	BeatmapSetID      int
-	FileFormat        string `json:"fileFormat"`
+	FileFormat        int `json:"fileFormat"`
 	Mode              int
 	AudioLeadIn       int
 	SampleSet         string

--- a/parser.go
+++ b/parser.go
@@ -37,9 +37,9 @@ func (b *beatmapParser) ReadLine(line string) (err error) {
 		b.EventLines = append(b.EventLines, line)
 	default:
 		if b.OsuSection == "" {
-			fmtRegex := regexp.MustCompile("^osu file format (v[0-9]+)$")
+			fmtRegex := regexp.MustCompile(`osu file format v(\d+)$`)
 			if match := fmtRegex.FindStringSubmatch(line); match != nil {
-				b.FileFormat = match[1]
+				b.FileFormat, _ = strconv.Atoi(match[1])
 				return
 			}
 		}
@@ -79,7 +79,7 @@ func (b *beatmapParser) ReadLine(line string) (err error) {
 					return
 				}
 			case "FileFormat":
-				b.FileFormat = match[2]
+				b.FileFormat, _ = strconv.Atoi(match[2])
 			case "Mode":
 				if b.Mode, err = strconv.Atoi(match[2]); err != nil {
 					return

--- a/testfiles/v10_out.json
+++ b/testfiles/v10_out.json
@@ -18,7 +18,7 @@
 	"Version": "Insane",
 	"BeatmapID": 170428,
 	"BeatmapSetID": 56348,
-	"fileFormat": "v10",
+	"fileFormat": 10,
 	"Mode": 0,
 	"AudioLeadIn": 2000,
 	"SampleSet": "Soft",

--- a/testfiles/v11_out.json
+++ b/testfiles/v11_out.json
@@ -17,7 +17,7 @@
 	"Version": "Insane",
 	"BeatmapID": 208927,
 	"BeatmapSetID": 73333,
-	"fileFormat": "v11",
+	"fileFormat": 11,
 	"Mode": 0,
 	"AudioLeadIn": 0,
 	"SampleSet": "Normal",

--- a/testfiles/v12_out.json
+++ b/testfiles/v12_out.json
@@ -19,7 +19,7 @@
 	"Version": "Time",
 	"BeatmapID": 263368,
 	"BeatmapSetID": 98842,
-	"fileFormat": "v12",
+	"fileFormat": 12,
 	"Mode": 0,
 	"AudioLeadIn": 0,
 	"SampleSet": "Soft",

--- a/testfiles/v13_out.json
+++ b/testfiles/v13_out.json
@@ -18,7 +18,7 @@
 	"Version": "Insane",
 	"BeatmapID": 354253,
 	"BeatmapSetID": 110126,
-	"fileFormat": "v13",
+	"fileFormat": 13,
 	"Mode": 0,
 	"AudioLeadIn": 1000,
 	"SampleSet": "Soft",

--- a/testfiles/v14_out.json
+++ b/testfiles/v14_out.json
@@ -20,7 +20,7 @@
 	"Version": "Insane",
 	"BeatmapID": 0,
 	"BeatmapSetID": 1,
-	"fileFormat": "v14",
+	"fileFormat": 14,
 	"Mode": 0,
 	"AudioLeadIn": 3575,
 	"SampleSet": "Soft",

--- a/testfiles/v3_out.json
+++ b/testfiles/v3_out.json
@@ -10,7 +10,7 @@
 	"Version": "Easy/Normal",
 	"BeatmapID": 0,
 	"BeatmapSetID": 0,
-	"fileFormat": "v3",
+	"fileFormat": 3,
 	"Mode": 0,
 	"AudioLeadIn": 0,
 	"SampleSet": "Normal",

--- a/testfiles/v4_out.json
+++ b/testfiles/v4_out.json
@@ -10,7 +10,7 @@
 	"Version": "Easy",
 	"BeatmapID": 0,
 	"BeatmapSetID": 0,
-	"fileFormat": "v4",
+	"fileFormat": 4,
 	"Mode": 0,
 	"AudioLeadIn": 1512,
 	"SampleSet": "Normal",

--- a/testfiles/v5_out.json
+++ b/testfiles/v5_out.json
@@ -12,7 +12,7 @@
 	"Version": "Easy",
 	"BeatmapID": 0,
 	"BeatmapSetID": 0,
-	"fileFormat": "v5",
+	"fileFormat": 5,
 	"Mode": 0,
 	"AudioLeadIn": 1007,
 	"SampleSet": "Soft",

--- a/testfiles/v7_out.json
+++ b/testfiles/v7_out.json
@@ -15,7 +15,7 @@
 	"Version": "Hard",
 	"BeatmapID": 0,
 	"BeatmapSetID": 0,
-	"fileFormat": "v7",
+	"fileFormat": 7,
 	"Mode": 0,
 	"AudioLeadIn": 0,
 	"SampleSet": "Soft",

--- a/testfiles/v8_out.json
+++ b/testfiles/v8_out.json
@@ -12,7 +12,7 @@
 	"Version": "Hard",
 	"BeatmapID": 0,
 	"BeatmapSetID": 0,
-	"fileFormat": "v8",
+	"fileFormat": 8,
 	"Mode": 0,
 	"AudioLeadIn": 1500,
 	"SampleSet": "Soft",

--- a/testfiles/v9_out.json
+++ b/testfiles/v9_out.json
@@ -14,7 +14,7 @@
 	"Version": "Another",
 	"BeatmapID": 0,
 	"BeatmapSetID": 0,
-	"fileFormat": "v9",
+	"fileFormat": 9,
 	"Mode": 0,
 	"AudioLeadIn": 0,
 	"SampleSet": "Soft",


### PR DESCRIPTION
Here's another tiny change, it is sometimes useful to compare file formats against some minimum like `format > 8`. 

I'm not sure if keeping compatibility with the node version is a priority, if so feel free to close this.

I might have other changes coming in the next little while, I'm using this for a project I'm working on :slightly_smiling_face:

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/natsukagami/go-osu-parser/2)
<!-- Reviewable:end -->
